### PR TITLE
Spring-Batch 과제 PR - 데이브

### DIFF
--- a/src/main/kotlin/se/ohou/example/PersonJob.kt
+++ b/src/main/kotlin/se/ohou/example/PersonJob.kt
@@ -13,7 +13,6 @@ import org.springframework.batch.item.json.builder.JsonFileItemWriterBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ClassPathResource
-import org.springframework.core.io.FileSystemResource
 
 @Configuration
 class PersonJob(
@@ -46,7 +45,7 @@ class PersonJob(
             .resource(ClassPathResource("sample-data.csv"))
             .lineMapper { line, _ ->
                 val splitLine = line.split(",")
-                Person(splitLine[0], splitLine[1].toInt())
+                Person(splitLine.getOrNull(0) ?: "", splitLine.getOrNull(1)?.toInt() ?: 0)
             }.build()
     }
 
@@ -64,7 +63,7 @@ class PersonJob(
         return JsonFileItemWriterBuilder<Person>()
             .name("jsonWriter")
             .jsonObjectMarshaller(JacksonJsonObjectMarshaller())
-            .resource(FileSystemResource("${System.getProperty("user.dir")}/src/main/resources/sample-data.json"))
+            .resource(ClassPathResource("sample-data.json"))
             .build()
     }
 }

--- a/src/main/kotlin/se/ohou/example/PersonJob.kt
+++ b/src/main/kotlin/se/ohou/example/PersonJob.kt
@@ -19,7 +19,6 @@ class PersonJob(
     val jobBuilderFactory: JobBuilderFactory,
     val stepBuilderFactory: StepBuilderFactory
 ) {
-
     @Bean
     fun personProcessingJob(): Job = jobBuilderFactory.get("personProcessingJob")
         .flow(personProcessingStep())

--- a/src/main/kotlin/se/ohou/example/PersonJob.kt
+++ b/src/main/kotlin/se/ohou/example/PersonJob.kt
@@ -9,17 +9,19 @@ import org.springframework.batch.item.ItemReader
 import org.springframework.batch.item.ItemWriter
 import org.springframework.batch.item.file.builder.FlatFileItemReaderBuilder
 import org.springframework.batch.item.json.JacksonJsonObjectMarshaller
-import org.springframework.batch.item.json.JsonFileItemWriter
 import org.springframework.batch.item.json.builder.JsonFileItemWriterBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.io.ClassPathResource
+import org.springframework.core.io.FileSystemResource
 
 @Configuration
 class PersonJob(
     val jobBuilderFactory: JobBuilderFactory,
     val stepBuilderFactory: StepBuilderFactory
 ) {
+
+    private val RESOURCE_PATH = "${System.getProperty("user.dir")}/src/main/resources"
+
     @Bean
     fun personProcessingJob(): Job = jobBuilderFactory.get("personProcessingJob")
         .flow(personProcessingStep())
@@ -31,25 +33,38 @@ class PersonJob(
         // reader, processor, writer를 가진 tasklet step을 생성
         return stepBuilderFactory.get("personProcessingStep")
             .chunk<Person, Person>(1)
+            .reader(reader())
+            .processor(processor())
+            .writer(writer())
             .build()
     }
 
     @Bean
-    fun reader(): ItemReader<Person>? {
+    fun reader(): ItemReader<Person> {
         // sample-data.csv 파일을 읽어서 Person 도메인 객체로 컨버팅
-        return null
+        return FlatFileItemReaderBuilder<Person>()
+            .name("csvReader")
+            .resource(FileSystemResource("${RESOURCE_PATH}/sample-data.csv"))
+            .lineMapper { line, _ ->
+                val splitLine = line.split(",")
+                Person(splitLine[0], splitLine[1].toInt())
+            }.build()
     }
 
     @Bean
-    fun processor(): ItemProcessor<Person, Person>? {
-        // Person 객체안에 name을 모두 소문자로 변환
-        return null
+    fun processor(): ItemProcessor<Person, Person> {
+        return ItemProcessor {
+            Person(it.name.lowercase(), it.age)
+        }
     }
 
-
     @Bean
-    fun writer(): ItemWriter<Person>? {
+    fun writer(): ItemWriter<Person> {
         // Person 객체를 json 파일로 write (파일 위치는 상관없음)
-        return null
+        return JsonFileItemWriterBuilder<Person>()
+            .name("jsonWriter")
+            .jsonObjectMarshaller(JacksonJsonObjectMarshaller<Person>())
+            .resource(FileSystemResource("${RESOURCE_PATH}/sample-data.json"))
+            .build()
     }
 }

--- a/src/main/kotlin/se/ohou/example/PersonJob.kt
+++ b/src/main/kotlin/se/ohou/example/PersonJob.kt
@@ -12,6 +12,7 @@ import org.springframework.batch.item.json.JacksonJsonObjectMarshaller
 import org.springframework.batch.item.json.builder.JsonFileItemWriterBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
 import org.springframework.core.io.FileSystemResource
 
 @Configuration
@@ -19,8 +20,6 @@ class PersonJob(
     val jobBuilderFactory: JobBuilderFactory,
     val stepBuilderFactory: StepBuilderFactory
 ) {
-
-    private val RESOURCE_PATH = "${System.getProperty("user.dir")}/src/main/resources"
 
     @Bean
     fun personProcessingJob(): Job = jobBuilderFactory.get("personProcessingJob")
@@ -44,7 +43,7 @@ class PersonJob(
         // sample-data.csv 파일을 읽어서 Person 도메인 객체로 컨버팅
         return FlatFileItemReaderBuilder<Person>()
             .name("csvReader")
-            .resource(FileSystemResource("${RESOURCE_PATH}/sample-data.csv"))
+            .resource(ClassPathResource("sample-data.csv"))
             .lineMapper { line, _ ->
                 val splitLine = line.split(",")
                 Person(splitLine[0], splitLine[1].toInt())
@@ -53,6 +52,7 @@ class PersonJob(
 
     @Bean
     fun processor(): ItemProcessor<Person, Person> {
+        // Person 객체안에 name을 모두 소문자로 변환
         return ItemProcessor {
             Person(it.name.lowercase(), it.age)
         }
@@ -63,8 +63,8 @@ class PersonJob(
         // Person 객체를 json 파일로 write (파일 위치는 상관없음)
         return JsonFileItemWriterBuilder<Person>()
             .name("jsonWriter")
-            .jsonObjectMarshaller(JacksonJsonObjectMarshaller<Person>())
-            .resource(FileSystemResource("${RESOURCE_PATH}/sample-data.json"))
+            .jsonObjectMarshaller(JacksonJsonObjectMarshaller())
+            .resource(FileSystemResource("${System.getProperty("user.dir")}/src/main/resources/sample-data.json"))
             .build()
     }
 }

--- a/src/main/resources/sample-data.json
+++ b/src/main/resources/sample-data.json
@@ -1,0 +1,7 @@
+[
+ {"name":"jill","age":20},
+ {"name":"joe","age":25},
+ {"name":"justin","age":30},
+ {"name":"jane","age":25},
+ {"name":"john","age":10}
+]


### PR DESCRIPTION
step, reader, processor, writer 구현하였습니다.

처음에 `FileSystemResource` 클래스를 사용하다가 `ClassPathResource` 클래스로 변경하려 하였으나 `writer` 에서 `ClassPathResource`를 사용해 빌드할 경우 json 파일에 제대로 데이터가 써지지 않아서 `FileSystemResource` 로 남겨놨습니다. 


```kotlin
fun writer(): ItemWriter<Person> {
        // Person 객체를 json 파일로 write (파일 위치는 상관없음)
        return JsonFileItemWriterBuilder<Person>()
            .name("jsonWriter")
            .jsonObjectMarshaller(JacksonJsonObjectMarshaller())
            .resource(FileSystemResource("${System.getProperty("user.dir")}/src/main/resources/sample-data.json"))
            .build()
    }
```

`reader`는 `ClassPathResource` 로 정상적으로 접근이 가능한데 왜 `writer`에서는 데이터가 쓰이지 않는지 모르겠습니다. 
